### PR TITLE
Data toolbar

### DIFF
--- a/src/components/ListDetailComponent/DataListComponent/DataListComponent.tsx
+++ b/src/components/ListDetailComponent/DataListComponent/DataListComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataList, PageSection } from '@patternfly/react-core';
+import { DataList, PageSection, Card } from '@patternfly/react-core';
 import ScrollArea from 'react-scrollbar';
 import './DataList.css';
 import DataListTitleComponent from '../DataListTitleComponent/DataListTitleComponent';
@@ -34,12 +34,15 @@ class DataListComponent extends React.Component<IOwnProps, IStateProps> {
       <React.Fragment>
         <DataListTitleComponent />
         <PageSection>
+          <Card>
+          <DataListToolbarComponent />
           <DataList aria-label="Expandable data list example">
-            <DataListToolbarComponent />
-            <ScrollArea smoothScrolling={true} style={{ width: '100%', height: '620px' }}>
+            <ScrollArea smoothScrolling={true}>
               {...this.state.dataListItemArray}
             </ScrollArea>
           </DataList>
+          </Card>
+
         </PageSection>
       </React.Fragment>
     );

--- a/src/components/ListDetailComponent/DataListItemComponent/DataListItemComponent.tsx
+++ b/src/components/ListDetailComponent/DataListItemComponent/DataListItemComponent.tsx
@@ -5,6 +5,7 @@ import {
   DataListToggle,
   DataListItemCells,
   DataListCell,
+  DataListCheck,
   Checkbox,
   TextContent,
   Text,
@@ -34,7 +35,7 @@ class DataListItemComponent extends React.Component<IOwnProps, IStateProps> {
   constructor(props) {
     super(props);
     this.state = {
-      expanded: ['ex-toggle'],
+      expanded: ['kie-datalist-toggle'],
       isOpen: false
     };
     this.onToggle = isOpen => {
@@ -59,40 +60,35 @@ class DataListItemComponent extends React.Component<IOwnProps, IStateProps> {
 
     return (
       <React.Fragment>
-        <DataListItem aria-labelledby="ex-item" isExpanded={!this.state.expanded.includes('ex-toggle')}>
+        <DataListItem aria-labelledby="kie-datalist-item" isExpanded={!this.state.expanded.includes('kie-datalist-toggle')}>
           <DataListItemRow>
             <DataListToggle
-              onClick={() => toggle('ex-toggle')}
-              isExpanded={!this.state.expanded.includes('ex-toggle')}
-              id="ex-toggle"
-              aria-controls="ex-expand"
+              onClick={() => toggle('kie-datalist-toggle')}
+              isExpanded={!this.state.expanded.includes('kie-datalist-toggle')}
+              id="kie-datalist-toggle"
+              aria-controls="kie-datalist-expand"
             />
-
+            <DataListCheck aria-labelledby="width-kie-datalist-item" name="width-kie-datalist-item" />  
             <DataListItemCells
               dataListCells={[
                 <DataListCell key="primary content">
-                  <div style={{ display: 'flex' }}>
-                    <div style={{ paddingTop: '8px', paddingRight: '16px' }}>
-                      <Checkbox label="" aria-label="controlled checkbox example" id="check" name="check" />
-                    </div>
-                    <TextContent>
-                      <Text component={TextVariants.p}>Instance {id}</Text>
-                    </TextContent>
-                  </div>
+                    Instance {id}
                 </DataListCell>,
                 <DataListCell key="secondary content">
-                  <div>Chart To Added</div>
+                  Chart to be added
                 </DataListCell>,
+                // this should be removed in favor of the action below... but I can't get the link to work on the action
                 <DataListCell key="secondary content 2">
-                  <div style={{ paddingLeft: '300px' }}>
                     <Link to={'/instanceDetail/' + id}>
-                      <Button variant="secondary">Details</Button>
+                      <Button variant="secondary">Old Details</Button>
                     </Link>
-                  </div>
                 </DataListCell>
               ]}
             />
-            <DataListAction aria-labelledby="ex-item1 ex-action1" id="ex-action" aria-label="Actions">
+            <DataListAction>
+              <Button variant="secondary" component="a" href={'/instanceDetail/' + id}>Details</Button>
+            </DataListAction>
+            <DataListAction aria-labelledby="kie-datalist-item kie-datalist-action" id="kie-datalist-action" aria-label="Actions">
               <Dropdown
                 isPlain
                 position={DropdownPosition.right}
@@ -110,8 +106,8 @@ class DataListItemComponent extends React.Component<IOwnProps, IStateProps> {
           </DataListItemRow>
           <DataListContent
             aria-label="Primary Content Details"
-            id="ex-expand1"
-            isHidden={this.state.expanded.includes('ex-toggle')}
+            id="kie-datalist-expand1"
+            isHidden={this.state.expanded.includes('kie-datalist-toggle')}
           >
             <p>More Information to be added here</p>
           </DataListContent>

--- a/src/components/ListDetailComponent/DataListToolbarComponent/DataListToolbarComponent.tsx
+++ b/src/components/ListDetailComponent/DataListToolbarComponent/DataListToolbarComponent.tsx
@@ -6,7 +6,10 @@ import {
   Button,
   ChipGroup,
   ChipGroupToolbarItem,
-  Chip
+  Chip,
+  Toolbar,
+  ToolbarItem,
+  ToolbarGroup
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 
@@ -31,8 +34,9 @@ class DataListToolbarComponent extends React.Component<IOwnProps, IStateProps> {
   render() {
     return (
       <React.Fragment>
-        <div className="styleToolBar" style={{ display: 'flex', paddingTop: '20px', paddingLeft: '22px' }}>
-          <div>
+        <Toolbar className="pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
+          <ToolbarGroup>
+          <ToolbarItem>
             <Dropdown
               toggle={
                 <DropdownToggle
@@ -42,32 +46,37 @@ class DataListToolbarComponent extends React.Component<IOwnProps, IStateProps> {
                 />
               }
             />
-          </div>
-          <div>
-            <Dropdown
-              toggle={
-                <DropdownToggle>
-                  <FilterIcon /> &nbsp;&nbsp; Dropdown
-                </DropdownToggle>
-              }
-              isGrouped
-            />
-          </div>
-          <div>
-            <Button variant="primary">Apply Filter</Button>
-          </div>
-          <div>
-            <ChipGroup withToolbar>
-              {this.state.chipGroups.map(currentGroup => (
-                <ChipGroupToolbarItem key={currentGroup.category} categoryName={currentGroup.category}>
-                  {currentGroup.chips.map(chip => (
-                    <Chip key={chip}>{chip}</Chip>
-                  ))}
-                </ChipGroupToolbarItem>
-              ))}
-            </ChipGroup>
-          </div>
-        </div>
+          </ToolbarItem>
+          </ToolbarGroup>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <Dropdown
+                toggle={
+                  <DropdownToggle>
+                    <FilterIcon /> &nbsp;&nbsp; Dropdown
+                  </DropdownToggle>
+                }
+                isGrouped
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Button variant="primary">Apply Filter</Button>
+            </ToolbarItem>
+          </ToolbarGroup>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <ChipGroup withToolbar>
+                {this.state.chipGroups.map(currentGroup => (
+                  <ChipGroupToolbarItem key={currentGroup.category} categoryName={currentGroup.category}>
+                    {currentGroup.chips.map(chip => (
+                      <Chip key={chip}>{chip}</Chip>
+                    ))}
+                  </ChipGroupToolbarItem>
+                ))}
+              </ChipGroup>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </Toolbar>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
This PR just adds the toolbar component in place of the vanilla div to take advantage of the space and other features provided by that component.
FYI: I have learned that there is a special data toolbar coming very soon in PF4 that is designed for exactly this use case - filtering a large data set. It's in experimental features right now (and can be used, but not guaranteed against breaking changes) https://www.patternfly.org/v4/documentation/react/experimental/datatoolbar/ 

This looks like a really good fit for our use case, but if we have tweaks that are needed, then we should loop back to the Patternfly team. They'll be finishing the component in the next week or two, and then it will hang out in Experimental features for a time in order to get feedback.

I am sending this PR to move in the right direction, but we should look at moving to that component.

@AjayJagan @cristianonicolai @kywalker-rh

